### PR TITLE
Change endpoint calls to query builder

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,14 +1,13 @@
 <?php
 
-define('SETTINGS', include __DIR__ . '/settings.php');
-
 /*
 * Gets the LIKE, LOVE, HAHA and WOW reaction counts from an object
 */
 function reactionCount($fb, $objectID, $accessToken)
 {
-    foreach (SETTINGS['REACTIONS'] as $key => $position) {
-        $fields[] = "reactions.type({$key}).limit(0).summary(total_count).as({$key})";
+    $activeReactions = ['LIKE', 'LOVE', 'HAHA', 'WOW'];
+    foreach ($activeReactions as $reaction) {
+        $fields[] = "reactions.type({$reaction}).limit(0).summary(total_count).as({$reaction})";
     }
     $reactionParams = ['ids' => $objectID, 'fields' => join(',', $fields)];
     $endpoint = '/?' . http_build_query($reactionParams);
@@ -67,7 +66,7 @@ function downloadProfileImage($uid, $width, $height)
 */
 function drawReactionCount($image, $reactions, $fontSettings)
 {
-    $activeReactions = array_keys(SETTINGS['REACTIONS']);
+    $activeReactions = ['LIKE', 'LOVE', 'HAHA', 'WOW'];
     foreach ($activeReactions as $reaction) {
         $image->text(
             $reactions[$reaction]['count'],

--- a/functions.php
+++ b/functions.php
@@ -67,7 +67,7 @@ function downloadProfileImage($uid, $width, $height)
 */
 function drawReactionCount($image, $reactions, $fontSettings)
 {
-    $activeReactions = keys(SETTINGS['REACTIONS']);
+    $activeReactions = array_keys(SETTINGS['REACTIONS']);
     foreach ($activeReactions as $reaction) {
         $image->text(
             $reactions[$reaction]['count'],


### PR DESCRIPTION
Query calls cleaned up by utilizing [http_build_query](http://php.net/manual/en/function.http-build-query.php)  to automatically generate endpoint parameters.