### PR TITLE
Bring settings into functions

### DIFF
--- a/fblive.php
+++ b/fblive.php
@@ -33,9 +33,9 @@ while (true) {
         $reactions,
         function (&$reaction, $key) use ($settings) {
             $reaction = [
-            'count' => $reaction['summary']['total_count'],
-            'xpos'  => $settings['REACTIONS'][$key]['XPOS'],
-            'ypos'  => $settings['REACTIONS'][$key]['YPOS']
+                'COUNT' => $reaction['summary']['total_count'],
+                'XPOS'  => $settings['REACTIONS'][$key]['XPOS'],
+                'YPOS'  => $settings['REACTIONS'][$key]['YPOS']
             ];
         }
     );
@@ -57,16 +57,18 @@ while (true) {
         }
     );
 
-    $latestShareComment = $comments[0];
+    $latestShareComment = isset($comments[0]) ? $comments[0] : null;
 
     /*
     * Download user profile image from Facebook. Image saves/overwrites to ./images/profile.jpeg
     */
-    downloadProfileImage(
-        $latestShareComment['from']['id'],
-        $settings['SHOUTOUT_IMAGE']['WIDTH'],
-        $settings['SHOUTOUT_IMAGE']['HEIGHT']
-    );
+    if ($latestShareComment !== null) {
+        downloadProfileImage(
+            $latestShareComment['from']['id'],
+            $settings['SHOUTOUT_IMAGE']['WIDTH'],
+            $settings['SHOUTOUT_IMAGE']['HEIGHT']
+        );
+    }
 
     /*
     * Add profile image to shoutout box
@@ -81,7 +83,11 @@ while (true) {
     /*
     * Draw reactions on image
     */
-    drawReactionCount($image, $reactions, $settings['REACTIONS_FONT']);
+    drawReactionCount(
+        $image,
+        $reactions,
+        $settings['REACTIONS_FONT']
+    );
 
     /*
     * Draw shoutout on image

--- a/fblive.php
+++ b/fblive.php
@@ -32,9 +32,14 @@ while (true) {
     array_walk(
         $reactions,
         function (&$reaction, $key) use ($settings) {
+            if (!empty($settings['REACTIONS'][$key]['XPOS'])) {
+                $xpos = $settings['REACTIONS'][$key]['XPOS'];
+            } else {
+                $xpos = calculateXPOS(array_search($key, array_keys($settings['REACTIONS'])));
+            }
             $reaction = [
                 'COUNT' => $reaction['summary']['total_count'],
-                'XPOS'  => $settings['REACTIONS'][$key]['XPOS'],
+                'XPOS'  => $xpos,
                 'YPOS'  => $settings['REACTIONS'][$key]['YPOS']
             ];
         }

--- a/functions.php
+++ b/functions.php
@@ -119,9 +119,9 @@ function getActiveReactions()
 */
 function calculateXPOS($index = 0)
 {
+    $imagePadding = 12;         // The padding on the edges, magic number
     $numberOfReactions = count(getActiveReactions());
-    $gridCenter = (IMAGE_WIDTH / $numberOfReactions) / 2;
+    $gridCenter = (IMAGE_WIDTH / $numberOfReactions) - $imagePadding;
     $textCenter = (SETTINGS['REACTIONS_FONT']['SIZE'] / 2);
-    $position = $index++;   // We want the index + 1
-    return ($gridCenter + $textCenter) * $position;
+    return ($gridCenter * $index) + ($gridCenter / 2) + $textCenter;
 }

--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,7 @@
 <?php
 
 define('SETTINGS', include __DIR__ . '/settings.php');
+define('IMAGE_WIDTH', 640);
 
 /*
 * Gets the LIKE, LOVE, HAHA and WOW reaction counts from an object
@@ -67,12 +68,11 @@ function downloadProfileImage($uid, $width, $height)
 */
 function drawReactionCount($image, $reactions, $fontSettings)
 {
-    $activeReactions = array_keys(SETTINGS['REACTIONS']);
-    foreach ($activeReactions as $reaction) {
+    foreach (getActiveReactions() as $index => $reaction) {
         $image->text(
-            $reactions[$reaction]['count'],
-            $reactions[$reaction]['xpos'],
-            $reactions[$reaction]['ypos'],
+            $reactions[$reaction]['COUNT'],
+            $reactions[$reaction]['XPOS'] ?: calculateXPOS($index),
+            $reactions[$reaction]['YPOS'],
             function ($font) use ($fontSettings) {
                 $font->file($fontSettings['FAMILY']);
                 $font->size($fontSettings['SIZE']);
@@ -104,4 +104,24 @@ function drawShoutout($image, $user, $shoutout, $settings)
     );
 
     return $image;
+}
+
+/*
+* Pull the active reactions from the settings file
+*/
+function getActiveReactions()
+{
+    return array_keys(SETTINGS['REACTIONS']);
+}
+
+/*
+* Calculate default X Position of a reaction by its index number
+*/
+function calculateXPOS($index = 0)
+{
+    $numberOfReactions = count(getActiveReactions());
+    $gridCenter = (IMAGE_WIDTH / $numberOfReactions) / 2;
+    $textCenter = (SETTINGS['REACTIONS_FONT']['SIZE'] / 2);
+    $position = $index++;   // We want the index + 1
+    return ($gridCenter + $textCenter) * $position;
 }

--- a/functions.php
+++ b/functions.php
@@ -67,7 +67,7 @@ function downloadProfileImage($uid, $width, $height)
 */
 function drawReactionCount($image, $reactions, $fontSettings)
 {
-    $activeReactions = keys(SETTINGS['REACTIONS']);
+    $activeReactions = array_keys(SETTINGS['REACTIONS']);
     foreach ($activeReactions as $reaction) {
         $image->text(
             $reactions[$reaction]['count'],


### PR DESCRIPTION
NOTE: Merge #5 first, this is built on top of it. There will probably be a conflict, so if that one is merged/closed, I'll modify this accordingly after.

This utilizes the settings file to automatically generate XPOS if not specified, and will also always use the settings file to render the image numbers on the stream. This avoids the possibility of configuring the emojis in a different order in settings, and having deploy screw up the order still, now order is consistent.

Also did some linting + validation checking on `fblive.php` as I noticed it wasn't very happy when there was no comments on the post yet, and we shouldn't be requesting profile images that don't request so often.